### PR TITLE
Target platforms for 2024-09 and 2024-12

### DIFF
--- a/devtools/oomph/SWTBot.setup
+++ b/devtools/oomph/SWTBot.setup
@@ -58,7 +58,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="eclipse.target.platform"
-      defaultValue="2024-06"
+      defaultValue="2024-12"
       storageURI="scope://Workspace"/>
   <setupTask
       xsi:type="setup:CompoundTask"
@@ -242,6 +242,28 @@
       <sourceLocator
           rootFolder="${git.clone.location}"
           locateNestedProjects="true"/>
+         <repositoryList
+          name="2024-12">
+        <repository
+            url="http://download.eclipse.org/releases/2024-12"/>
+        <repository
+            url="http://download.eclipse.org/cbi/updates/license"/>
+        <repository
+            url="http://download.eclipse.org/nebula/snapshot/"/>
+        <repository
+            url="http://download.eclipse.org/nattable/snapshots/latest/repository/"/>
+        </repositoryList>
+         <repositoryList
+          name="2024-09">
+        <repository
+            url="http://download.eclipse.org/releases/2024-09"/>
+        <repository
+            url="http://download.eclipse.org/cbi/updates/license"/>
+        <repository
+            url="http://download.eclipse.org/nebula/snapshot/"/>
+        <repository
+            url="http://download.eclipse.org/nattable/snapshots/latest/repository/"/>
+        </repositoryList>
         <repositoryList
           name="2024-06">
         <repository

--- a/devtools/target-platforms/2024-09/2024-09.target
+++ b/devtools/target-platforms/2024-09/2024-09.target
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="Eclipse 2024-09 via p2" sequenceNumber="1">
+<locations>
+<!-- Add dependencies that only exist with older orbit version -->
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.slf4j.api" version="0.0.0"/>
+<unit id="javax.inject" version="1.0.0.v20220405-0441"/>
+<unit id="javax.annotation" version="1.3.5.v20230504-0748"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository/"/>
+</location>	
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.platform.ide" version="0.0.0"/>
+<unit id="org.eclipse.emf.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
+<repository location="https://download.eclipse.org/releases/2024-09"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.junit" version="4.13.2.v20230809-1000"/>
+<unit id="junit-platform-engine" version="1.11.0"/>
+<unit id="junit-platform-launcher" version="1.11.0"/>
+<unit id="junit-platform-commons" version="1.11.0"/>
+<unit id="junit-jupiter-api" version="5.11.0"/>
+<unit id="junit-jupiter-engine" version="5.11.0"/>
+<unit id="junit-jupiter-migrationsupport" version="5.11.0"/>
+<unit id="junit-jupiter-params" version="5.11.0"/>
+<unit id="junit-platform-runner" version="1.11.0"/>
+<unit id="junit-platform-suite-api" version="1.11.0"/>
+<unit id="junit-vintage-engine" version="5.11.0"/>
+<unit id="ca.odell.glazedlists" version="0.0.0"/>
+<unit id="org.hamcrest.library" version="0.0.0"/>
+<unit id="org.hamcrest.library.source" version="0.0.0"/>
+<unit id="org.hamcrest.core" version="0.0.0"/>
+<unit id="org.hamcrest.core.source" version="0.0.0"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.33.0"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
+<repository location="https://download.eclipse.org/cbi/updates/license"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.nebula.widgets.gallery.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.nebula.widgets.opal.checkboxgroup.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.nebula.widgets.stepbar.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.nebula.widgets.opal.rangeslider.feature.feature.group" version="0.0.0"/>
+<repository location="https://download.eclipse.org/nebula/snapshot/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.nebula.widgets.nattable.core.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.nebula.widgets.nattable.extension.glazedlists.feature.feature.group" version="0.0.0"/>
+<repository location="https://download.eclipse.org/nattable/snapshots/latest/repository"/>
+</location>
+</locations>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+<launcherArgs>
+<vmArgs>-Xms128m -Xmx1024m</vmArgs>
+</launcherArgs>
+</target>

--- a/devtools/target-platforms/2024-12/2024-12.target
+++ b/devtools/target-platforms/2024-12/2024-12.target
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="Eclipse 2024-12 via p2" sequenceNumber="1">
+<locations>
+<!-- Add dependencies that only exist with older orbit version -->
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.slf4j.api" version="0.0.0"/>
+<unit id="javax.inject" version="1.0.0.v20220405-0441"/>
+<unit id="javax.annotation" version="1.3.5.v20230504-0748"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository/"/>
+</location>	
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.platform.ide" version="0.0.0"/>
+<unit id="org.eclipse.emf.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
+<repository location="https://download.eclipse.org/releases/2024-12"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.junit" version="4.13.2.v20240929-1000"/>
+<unit id="junit-platform-engine" version="1.11.3"/>
+<unit id="junit-platform-launcher" version="1.11.3"/>
+<unit id="junit-platform-commons" version="1.11.3"/>
+<unit id="junit-jupiter-api" version="5.11.3"/>
+<unit id="junit-jupiter-engine" version="5.11.3"/>
+<unit id="junit-jupiter-migrationsupport" version="5.11.3"/>
+<unit id="junit-jupiter-params" version="5.11.3"/>
+<unit id="junit-platform-runner" version="1.11.3"/>
+<unit id="junit-platform-suite-api" version="1.11.3"/>
+<unit id="junit-vintage-engine" version="5.11.3"/>
+<unit id="ca.odell.glazedlists" version="0.0.0"/>
+<unit id="org.hamcrest.library" version="0.0.0"/>
+<unit id="org.hamcrest.library.source" version="0.0.0"/>
+<unit id="org.hamcrest.core" version="0.0.0"/>
+<unit id="org.hamcrest.core.source" version="0.0.0"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.34.0"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
+<repository location="https://download.eclipse.org/cbi/updates/license"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.nebula.widgets.gallery.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.nebula.widgets.opal.checkboxgroup.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.nebula.widgets.stepbar.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.nebula.widgets.opal.rangeslider.feature.feature.group" version="0.0.0"/>
+<repository location="https://download.eclipse.org/nebula/snapshot/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.nebula.widgets.nattable.core.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.nebula.widgets.nattable.extension.glazedlists.feature.feature.group" version="0.0.0"/>
+<repository location="https://download.eclipse.org/nattable/snapshots/latest/repository"/>
+</location>
+</locations>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+<launcherArgs>
+<vmArgs>-Xms128m -Xmx1024m</vmArgs>
+</launcherArgs>
+</target>

--- a/devtools/target-platforms/swtbot-baseline.target
+++ b/devtools/target-platforms/swtbot-baseline.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="swtbot-baseline" sequenceNumber="23">
+<?pde version="3.8"?><target name="swtbot-baseline" sequenceNumber="24">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
@@ -17,7 +17,7 @@
 <repository location="https://download.eclipse.org/technology/swtbot/releases/4.1.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
-<repository location="https://download.eclipse.org/releases/2024-06"/>
+<repository location="https://download.eclipse.org/releases/2024-12"/>
 </location>
 </locations>
 </target>

--- a/org.eclipse.swtbot.eclipse.finder.test/src/org/eclipse/swtbot/eclipse/finder/widgets/SWTBotEclipseProjectTest.java
+++ b/org.eclipse.swtbot.eclipse.finder.test/src/org/eclipse/swtbot/eclipse/finder/widgets/SWTBotEclipseProjectTest.java
@@ -87,7 +87,7 @@ public class SWTBotEclipseProjectTest extends AbstractSWTBotEclipseTest {
 	@Test
 	public void canAccessContextMenuSubmenu() {
 		SWTBotMenu openWithMenu = javaClassFileTreeItem().contextMenu("Open With");
-		openWithMenu.menu("Text Editor").click();
+		openWithMenu.menu("Java Editor").click();
 	}
 	
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ Authors:
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>4.0.4</tycho-version>
+		<tycho-version>4.0.10</tycho-version>
 		<tycho-extras-version>${tycho-version}</tycho-extras-version>
 		<!-- Properties to enable jacoco code coverage analysis -->
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
@@ -959,7 +959,7 @@ Authors:
 		<profile>
 			<id>2024-06</id>
 			<activation>
-				<activeByDefault>true</activeByDefault>
+				<activeByDefault>false</activeByDefault>
 			</activation>
 			<build>
 				<plugins>
@@ -970,6 +970,46 @@ Authors:
 						<configuration>
 							<target>
 								<file>../devtools/target-platforms/2024-06/2024-06.target</file>
+							</target>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>2024-09</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>target-platform-configuration</artifactId>
+						<version>${tycho-version}</version>
+						<configuration>
+							<target>
+								<file>../devtools/target-platforms/2024-09/2024-09.target</file>
+							</target>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>2024-12</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>target-platform-configuration</artifactId>
+						<version>${tycho-version}</version>
+						<configuration>
+							<target>
+								<file>../devtools/target-platforms/2024-12/2024-12.target</file>
 							</target>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
Target platforms for 2024-09 and 2024-12
-Use latest tycho version 4.0.10 to avoid JDK warnings. 
-Minor change in SWTBotEclipseProjectTest.java to use different submenu since 'Text Editor' menu is changed to 'Plain Text Editor'.

Change-Id: Idd861ebf4c08b9aaf110d76011c08e71c0827f74