### PR TITLE
Add missing keys for semicolon, colon and underscore in german keyboard file

### DIFF
--- a/org.eclipse.swtbot.swt.finder/src/org/eclipse/swtbot/swt/finder/keyboard/DE_DE.keyboard
+++ b/org.eclipse.swtbot.swt.finder/src/org/eclipse/swtbot/swt/finder/keyboard/DE_DE.keyboard
@@ -29,3 +29,6 @@ $ shift+4
 - -
 . .
 , ,
+; shift+,
+: shift+.
+_ shift+-


### PR DESCRIPTION
The keyboard file was missing definitions for semicolon, colon and underscore