### PR TITLE
Update deprecated actions and setup JDK 21 in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,17 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Set up Maven
-      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      uses: stCarolas/setup-maven@v5
       with:
         maven-version: 3.9.5
     - name: Install and start Metacity window manager
@@ -40,7 +40,7 @@ jobs:
     - name: Build with Maven
       run: mvn clean verify
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: Build artifacts
@@ -49,7 +49,7 @@ jobs:
           **/target/**/*.log
           **/hs_err_pid*.log
     - name: Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: Test results

--- a/org.eclipse.swtbot.swt.finder.test/src/org/eclipse/swtbot/swt/finder/test/AbstractSWTShellTest.java
+++ b/org.eclipse.swtbot.swt.finder.test/src/org/eclipse/swtbot/swt/finder/test/AbstractSWTShellTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2024 Ketan Padegaonkar and others.
+ * Copyright (c) 2010, 2025 Ketan Padegaonkar and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotText;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
+import org.junit.BeforeClass;
 
 /**
  * @author Ketan Padegaonkar &lt;KetanPadegaonkar [at] gmail [dot] com&gt;
@@ -37,7 +38,8 @@ import org.hamcrest.StringDescription;
  */
 public abstract class AbstractSWTShellTest extends AbstractSWTTest {
 
-	static {
+	@BeforeClass
+	public static void beforeClass() {
 		SWTBotPreferences.KEYBOARD_LAYOUT = "EN_US";
 	}
 


### PR DESCRIPTION
Build action was failing due to deprecated actions, so update ci.yml for actions checkout@v4, upload-artifact@v4, setup-java@v4, setup-maven@v5.

Update setup-java@v4 action to Java 21 in ci.yml.