### PR TITLE
Dependabot for checking for updates of GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This should avoid problems like the ones of https://github.com/eclipse-swtbot/org.eclipse.swtbot/pull/21