### PR TITLE
Update to Tycho 5.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.5
+        maven-version: 3.9.11
     - name: Install and start Metacity window manager
       run: |
         sudo apt-get update

--- a/org.eclipse.swtbot.e4.finder.test/pom.xml
+++ b/org.eclipse.swtbot.e4.finder.test/pom.xml
@@ -72,7 +72,6 @@ Authors:
 					<useUIThread>false</useUIThread>
 					<product>org.eclipse.swtbot.e4.finder.test.product</product>
 					<application>org.eclipse.e4.ui.workbench.swt.E4Application</application>
-					<testSuite>org.eclipse.swtbot.e4.finder.test</testSuite>
 					<testClass>org.eclipse.swtbot.e4.finder.test.AllTests</testClass>
 					<environmentVariables>
 						<!-- Ubuntu overlay scrollbars cause different crashes in GTK2 so disable them -->

--- a/org.eclipse.swtbot.eclipse.finder.test/pom.xml
+++ b/org.eclipse.swtbot.eclipse.finder.test/pom.xml
@@ -71,7 +71,6 @@ Authors:
 					<useUIThread>false</useUIThread>
 					<product>org.eclipse.platform.ide</product>
 					<application>org.eclipse.ui.ide.workbench</application>
-					<testSuite>org.eclipse.swtbot.eclipse.finder.test</testSuite>
 					<testClass>org.eclipse.swtbot.eclipse.finder.AllTests</testClass>
 					<environmentVariables>
 						<!-- Ubuntu overlay scrollbars cause different crashes in GTK2 so disable them -->

--- a/org.eclipse.swtbot.eclipse.ui.test/pom.xml
+++ b/org.eclipse.swtbot.eclipse.ui.test/pom.xml
@@ -71,7 +71,6 @@ Authors:
 					<useUIThread>false</useUIThread>
 					<product>org.eclipse.sdk.ide</product>
 					<application>org.eclipse.ui.ide.workbench</application>
-					<testSuite>org.eclipse.swtbot.eclipse.ui.test</testSuite>
 					<testClass>org.eclipse.swtbot.eclipse.ui.functional.AllTests</testClass>
 					<environmentVariables>
 						<!-- Ubuntu overlay scrollbars cause different crashes in GTK2 so disable them -->

--- a/org.eclipse.swtbot.forms.finder.test/pom.xml
+++ b/org.eclipse.swtbot.forms.finder.test/pom.xml
@@ -71,7 +71,6 @@ Authors:
 					<useUIThread>false</useUIThread>
 					<product>org.eclipse.sdk.ide</product>
 					<application>org.eclipse.ui.ide.workbench</application>
-					<testSuite>org.eclipse.swtbot.forms.finder.test</testSuite>
 					<testClass>org.eclipse.swtbot.forms.finder.test.AllTests</testClass>
 					<environmentVariables>
 						<!-- Ubuntu overlay scrollbars cause different crashes in GTK2 so disable them -->

--- a/org.eclipse.swtbot.nebula.gallery.finder.test/pom.xml
+++ b/org.eclipse.swtbot.nebula.gallery.finder.test/pom.xml
@@ -34,7 +34,6 @@ Authors:
 					<argLine>${uitest.vmparams}</argLine>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
-					<testSuite>org.eclipse.swtbot.nebula.gallery.finder.test</testSuite>
 					<testClass>org.eclipse.swtbot.nebula.gallery.finder.test.AllTests</testClass>
 					<environmentVariables>
 						<!-- Ubuntu overlay scrollbars cause different crashes in GTK2 so disable them -->

--- a/org.eclipse.swtbot.nebula.nattable.finder.test/pom.xml
+++ b/org.eclipse.swtbot.nebula.nattable.finder.test/pom.xml
@@ -34,7 +34,6 @@ Authors:
 					<argLine>${uitest.vmparams}</argLine>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
-					<testSuite>org.eclipse.swtbot.nebula.nattable.finder.test</testSuite>
 					<testClass>org.eclipse.swtbot.nebula.nattable.finder.test.AllTests</testClass>
 					<environmentVariables>
 						<!-- Ubuntu overlay scrollbars cause different crashes in GTK2 so disable them -->

--- a/org.eclipse.swtbot.updatesite/category.xml
+++ b/org.eclipse.swtbot.updatesite/category.xml
@@ -39,39 +39,6 @@
    <feature id="org.eclipse.swtbot.junit5" version="0.0.0">
       <category name="SWTBot - JUnit5 Support"/>
    </feature>
-   <feature id="org.eclipse.swtbot.source" version="0.0.0">
-      <category name="SWTBot - Sources"/>
-   </feature>
-   <feature id="org.eclipse.swtbot.eclipse.source" version="0.0.0">
-      <category name="SWTBot - Sources"/>
-   </feature>
-   <feature id="org.eclipse.swtbot.eclipse.gef.source" version="0.0.0">
-      <category name="SWTBot - Sources"/>
-   </feature>
-   <feature id="org.eclipse.swtbot.forms.source" version="0.0.0">
-      <category name="SWTBot - Sources"/>
-   </feature>
-   <feature id="org.eclipse.swtbot.ide.source" version="0.0.0">
-      <category name="SWTBot - Sources"/>
-   </feature>
-   <feature id="org.eclipse.swtbot.generator.feature.source" version="0.0.0">
-      <category name="SWTBot - Sources"/>
-   </feature>
-   <feature id="org.eclipse.swtbot.nebula.gallery.source" version="0.0.0">
-      <category name="SWTBot - Sources"/>
-   </feature>
-   <feature id="org.eclipse.swtbot.nebula.nattable.source" version="0.0.0">
-      <category name="SWTBot - Sources"/>
-   </feature>
-   <feature id="org.eclipse.swtbot.nebula.checkboxgroup.source" version="0.0.0">
-      <category name="SWTBot - Sources"/>
-   </feature>
-   <feature id="org.eclipse.swtbot.nebula.stepbar.source" version="0.0.0">
-      <category name="SWTBot - Sources"/>
-   </feature>
-   <feature id="org.eclipse.swtbot.nebula.rangeslider.source" version="0.0.0">
-      <category name="SWTBot - Sources"/>
-   </feature>
    <bundle id="org.hamcrest" version="0.0.0">
       <category name="SWTBot -- Dependencies"/>
    </bundle>
@@ -81,13 +48,9 @@
    <bundle id="slf4j.api">
       <category name="SWTBot -- Dependencies"/>
    </bundle>
-   <bundle id="slf4j.api.source">
-      <category name="SWTBot -- Dependencies"/>
-   </bundle>
    <category-def name="SWTBot - API" label="SWTBot - API"/>
    <category-def name="SWTBot - IDE Integration" label="SWTBot - IDE Integration"/>
    <category-def name="SWTBot - Headless Support" label="SWTBot - Headless Support"/>
    <category-def name="SWTBot - JUnit5 Support" label="SWTBot - JUnit5 Support"/>
-   <category-def name="SWTBot - Sources" label="SWTBot - Sources"/>
    <category-def name="SWTBot -- Dependencies" label="SWTBot -- Dependencies"/>
 </site>

--- a/org.eclipse.swtbot.updatesite/pom.xml
+++ b/org.eclipse.swtbot.updatesite/pom.xml
@@ -25,4 +25,17 @@ Authors:
   	<relativePath>../pom.xml</relativePath>
   </parent>
 
+  <build>
+    <plugins>
+      <plugin>
+         <groupId>org.eclipse.tycho</groupId>
+         <artifactId>tycho-p2-repository-plugin</artifactId>
+         <version>${tycho-version}</version>
+         <configuration>
+            <repositoryName>SWTBot Updates</repositoryName>
+            <includeAllSources>true</includeAllSources>
+         </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ Authors:
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>4.0.12</tycho-version>
+		<tycho-version>5.0.0</tycho-version>
 		<tycho-extras-version>${tycho-version}</tycho-extras-version>
 		<!-- Properties to enable jacoco code coverage analysis -->
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
@@ -35,6 +35,7 @@ Authors:
 		<uitest.vmparams>${tycho.testArgLine} -Xms64m -Xmx1024m</uitest.vmparams>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<slf4jVersion>1.7.30</slf4jVersion>
+		<jarsigner-version>1.5.2</jarsigner-version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -167,7 +168,6 @@ Authors:
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<resolver>p2</resolver>
 					<environments>
 						<environment>
 							<os>linux</os>
@@ -185,7 +185,6 @@ Authors:
 							<arch>x86_64</arch>
 						</environment>
 					</environments>
-					<includePackedArtifacts>true</includePackedArtifacts>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -236,25 +235,13 @@ Authors:
 							<goal>plugin-source</goal>
 						</goals>
 					</execution>
-					<execution>
-						<id>feature-source</id>
-						<goals>
-							<goal>feature-source</goal>
-						</goals>
-						<configuration>
-							<excludes>
-								<plugin id="org.apache.log4j"/>
-								<plugin id="org.eclipse.swtbot.ant.junit"/>
-							</excludes>
-						</configuration>
-					</execution>
 				</executions>
 			</plugin>
 			<!-- Those mojos are for signing and packing -->
 			<plugin>
 				<groupId>org.eclipse.cbi.maven.plugins</groupId>
 				<artifactId>eclipse-jarsigner-plugin</artifactId>
-				<version>1.3.2</version>
+				<version>${jarsigner-version}</version>
 				<executions>
 					<execution>
 						<id>sign</id>


### PR DESCRIPTION
- Use latest jar signer version.
- Eliminate parameters that produce warnings because they are unused, e.g., resolver, includePackedArtifacts, and testSuite.
- Stop building source features.
- Ensure that the repository nevertheless contains corresponding sources for all bundles.